### PR TITLE
Fix an error where the image link is invalid

### DIFF
--- a/async_cse/search.py
+++ b/async_cse/search.py
@@ -92,6 +92,8 @@ class Result:
                     else:
                         try:
                             image_url = img[0]["src"]
+                            if image_url.startswith("x-raw-image"):
+                                image_url = i["cse_thumbnail"][0]["src"]
                         except TypeError:
                             image_url = GOOGLE_FAVICON
             results.append(cls(title, desc, url, image_url))


### PR DESCRIPTION

![screenshot_20190105074007](https://user-images.githubusercontent.com/42074408/50719175-74262b80-10be-11e9-8059-15e941a73872.png)
Discord threw this ☝️
Randomly in my Google search command. So I "investigated" it and found that the `"cse_image"` for certain searches has a URL of the sort "x-raw-image:///\<stuff\>". Discord obviously doesn't recognise this as an image url. Nor did I . So I opened up the json response of cse for that specific search and tried to find a solution. The only one I found was the `"cse_thumbnail"` attribute. (Which isn't as high quality but is the only alternative) . There was of course another image url in the json, `"og:image"`. But its url was broken.

So here's a tiny fix for the error. 
Also, you can reproduce the error by searching "free code camp python" and it's in the first result.